### PR TITLE
introduce \norm, \abs, \scaProd via \DeclarePairedDelimiter

### DIFF
--- a/MFANA/MFANA.tex
+++ b/MFANA/MFANA.tex
@@ -14,7 +14,7 @@
 
 \setlength{\parindent}{0px} %dieser Befehl verhindert das Einrücken eines Absatzes bei einer leeren Codezeile.
 
-\title{%
+\title{
   Vorlesung\\
   Methoden der Funktionalanalysis \\
   }

--- a/MFANA/chapter4.tex
+++ b/MFANA/chapter4.tex
@@ -309,41 +309,41 @@ Bezüglich der Wohlgestelltheit des Cauchyproblems mit \ul{linearem} $A$ gilt de
 		\Vert S_t\Vert_{\L(X)}\leq M\cdot\exp(\omega\cdot t)\qquad\forall t\in\R_+
 	\end{align*}
 	($M\geq1,\omega\in\R$). 
-	Dann gibt es auf dem Banachraum $X$ eine äquivalente Norm $\Vertiii{\cdot}$, so dass
+	Dann gibt es auf dem Banachraum $X$ eine äquivalente Norm $\normiii{\cdot}$, so dass
 	\begin{align*}
-		\Vertiii{S_t}_{\L(X)}\leq\exp(\omega\cdot t)\qquad\forall t\in\R_+
+		\normiii{S_t}_{\L(X)}\leq\exp(\omega\cdot t)\qquad\forall t\in\R_+
 	\end{align*} 
 \end{bemerkung}
 
 \begin{proof}
 	Setze
 	\begin{align*}
-		\Vertiii{x}:=\sup\limits_{t\geq0}\exp(-\omega\cdot t)\cdot\Vert S_t x\Vert\qquad\forall x\in X
+		\normiii{x}:=\sup\limits_{t\geq0}\exp(-\omega\cdot t)\cdot\Vert S_t x\Vert\qquad\forall x\in X
 	\end{align*}
 	Das ist offenbar eine Norm auf $XR$ und es gilt 
 	\begin{align*}
-		\Vertiii{x}\leq M\cdot\Vert x\Vert
+		\normiii{x}\leq M\cdot\Vert x\Vert
 	\end{align*}
 	(exponentielle Abschätzung für $S$) und 
 	\begin{align*}
-		\Vert x\Vert=\Vert S_0 x\Vert\leq\Vertiii{x},
+		\norm{x}=\norm{S_0 x}\leq\normiii{x},
 	\end{align*}
-	d.h. $\Vertiii{x}$ \underline{ist} äquivalente Norm auf $X$. 
+	d.h. $\normiii{x}$ \underline{ist} äquivalente Norm auf $X$. 
 	Außerdem gilt für alle $x\in X, s\in\R_+$:
 	\begin{align*}
-		\Vertiii{S_s x}
+		\normiii{S_s x}
 		&=\sup\limits_{t\geq0}\exp(-\omega\cdot t)\cdot\big\Vert S_t\cdot S_s\big\Vert\\
 		&=\sup\limits_{t\geq0}\exp(-\omega\cdot t)\cdot\big\Vert S_{t+s}\big\Vert\\
 		&=\sup\limits_{t\geq0}\exp\big(-\omega\cdot(t+s)\big)\cdot\big\Vert S_{t+s}\big\Vert\cdot\exp(\omega\cdot s)\\
 		&=\exp(\omega\cdot s)\cdot\sup\limits_{t\geq s}\exp(-\omega\cdot t)\cdot\big\Vert S_{t}\big\Vert\\\
-		&\leq\exp(\omega\cdot s)\cdot\Vertiii{x}\\
-		\implies \Vertiii{S_s}_{\L(X)}&\leq\exp(\omega\cdot s)
+		&\leq\exp(\omega\cdot s)\cdot\normiii{x}\\
+		\implies \normiii{S_s}_{\L(X)}&\leq\exp(\omega\cdot s)
 	\end{align*}
 \end{proof}
 
 \begin{theorem}[Ohne Namen]\enter
 	Ein linearer Operator $A$ auf einem Banachraum $X$ ist genau dann Erzeuger einer linearer Halbgruppe, 
-	wenn $\dom(A)$ dicht in $X$ ist und wenn es eine äquivalente Norm $\Vertiii{\cdot}$ auf $X$ gibt bzgl. der $-A$ $m$-akkretiv vom Typ $\omega$ ist.
+	wenn $\dom(A)$ dicht in $X$ ist und wenn es eine äquivalente Norm $\normiii{\cdot}$ auf $X$ gibt bzgl. der $-A$ $m$-akkretiv vom Typ $\omega$ ist.
 \end{theorem}
 
 Mit diesem Theorem (+ obiger Bemerkung) sind alle Erzeuger von linearen Halbgruppen auf Banachräumen charakterisiert.

--- a/PDENUM/Loesungen/Blatt_3_content.tex
+++ b/PDENUM/Loesungen/Blatt_3_content.tex
@@ -248,13 +248,13 @@ Geben Sie eine hinreichende Bedingung an, unter denen die eindeutige Lösbarkeit
 	Um die Voraussetzungen noch weiter abzuschwächen, können wir Theorem 1.11 aus der Vorlesung verwenden. 
 	Die Norm
 	\begin{align*}
-		\Vertiii{f}:=|f|_{1,2,\Omega}+\big|F(f)\big|+\sqrt{B(f,f)}
+		\normiii{f}:=\abs{f}_{1,2,\Omega}+\abs[\big]{F(f)}+\sqrt{B(f,f)}
 	\end{align*}
 	ist äquivalent zu $\Vert f\Vert_{1,2,\Omega}$, wenn:
 	\begin{enumerate}
 		\item $B$ stetig, symmetrisch, bilinear auf $H^1(\Omega)$, $B(v,v)\geq0~\forall v\in V$
 		\item $F$ linear, stetig auf $H^1(\Omega)$
-		\item $\big|F(1)\big|+\sqrt{B(1,1)}>0$ für $f\equiv1$
+		\item $\abs[\big]{F(1)}+\sqrt{B(1,1)}>0$ für $f\equiv1$
 	\end{enumerate}
 	
 	\begin{align*}

--- a/PDENUM/section1.tex
+++ b/PDENUM/section1.tex
@@ -290,35 +290,35 @@ Bezeichnungen für dieses Kapitel:
 	Dann gilt:\\
 	Die Normen $\Vert\cdot\Vert_{1,2,\Omega}$ und
 	\begin{align*}
-		\Vertiii{f}:=|f|_{1,2,\Omega}+|F(f)|+\sqrt{B(f,f)}
+		\normiii{f}:=\abs{f}_{1,2,\Omega}+\abs{F(f)}+\sqrt{B(f,f)}
 	\end{align*}
 	sind äquivalent auf $H^1(\Omega)$, d. h. es existieren $c_1,c_2>0$ so, dass
 	\begin{align*}
-		c_1\cdot\Vert f\Vert_{1,2,\Omega}\leq\Vertiii{f}
+		c_1\cdot\norm{f}_{1,2,\Omega}\leq\normiii{f}
 		\leq
-		c_2\cdot\Vert f\Vert_{1,2,\Omega}
+		c_2\cdot\norm{f}_{1,2,\Omega}
 		\qquad\forall f\in H^1(\Omega)
 	\end{align*}
 \end{proposition}
 
 \begin{proof}
-	\underline{Zeige $\Vertiii{\cdot}$ ist eine Norm:}
+	\underline{Zeige $\normiii{\cdot}$ ist eine Norm:}
 	Dies wird in der Übung gezeigt.\nl
-	\underline{Zeige $\Vertiii{f}\leq c_2\cdot\Vert f\Vert_{1,2,\Omega}$:}
+	\underline{Zeige $\normiii{f}\leq c_2\cdot\norm{f}_{1,2,\Omega}$:}
 	\begin{align*}
-		\Vertiii{f} &=
-		|f|_{1,2,\Omega}+|F(f)|+\sqrt{B(f,f)}\\
+		\normiii{f} &=
+		\abs{f}_{1,2,\Omega}+\abs{F(f)}+\sqrt{B(f,f)}\\
 		&\leq
-		\Vert f\Vert_{1,2,\Omega} +c_F\cdot\Vert f\Vert_{1,2,\Omega}+\sqrt{c_B\cdot\Vert f\Vert^2_{1,2,\Omega}}\\
+		\norm{f}_{1,2,\Omega} +c_F\cdot\norm{f}_{1,2,\Omega}+\sqrt{c_B\cdot\norm{f}^2_{1,2,\Omega}}\\
 		&\leq
-		(1+c_F+\sqrt{c_B})\cdot\Vert f\Vert_{1,2,\Omega}
+		(1+c_F+\sqrt{c_B})\cdot\norm{f}_{1,2,\Omega}
 	\end{align*}
 
 	%(iii)
-	\underline{Zeige $\Vert f\Vert_{0,2,\Omega}\leq c\cdot\Vertiii{f}$ indirekt:}
+	\underline{Zeige $\norm{f}_{0,2,\Omega}\leq c\cdot\normiii{f}$ indirekt:}
 	Angenommen es gibt eine Folge $(f_n)_{n\in\N}\subseteq H^1(\Omega)$ mit
 	\begin{align}\label{proof1.9}\tag{$\ast$}
-		\Vert f_n\Vert_{0,2,\Omega}=1\text{ und }\Vertiii{f_n}<\frac{1}{n}~\forall n\in\N
+		\norm{f_n}_{0,2,\Omega}=1\text{ und }\normiii{f_n}<\frac{1}{n}~\forall n\in\N
 	\end{align}
 	Dann gilt für alle $n\in\N$:
 	\begin{align*}
@@ -338,10 +338,10 @@ Bezeichnungen für dieses Kapitel:
 		&\implies
 		f\text{ ist konstant, also } f\equiv \lambda\cdot g\mit\lambda\in\R
 	\end{align*}
-	Mit $\Vertiii{f}=0$ erhalten wir
+	Mit $\normiii{f}=0$ erhalten wir
 	\begin{align*}
-		\Vertiii{f} = 0
-		&=|f|_{1,2,\Omega}+|F(f)|+\sqrt{B(f,f)}\\
+		\normiii{f} = 0
+		&=\abs{f}_{1,2,\Omega}+|F(f)|+\sqrt{B(f,f)}\\
 		&=0+|\lambda|\cdot|F(g)|+|\lambda|\cdot\sqrt{B(g,g)}\\
 		&=|\lambda|\cdot\underbrace{\Big(|F(g)|+\sqrt{B(g,g)}\Big)}_{>0}\\
 		&\implies\lambda=0\implies f\equiv 0
@@ -349,18 +349,18 @@ Bezeichnungen für dieses Kapitel:
 	Das ist ein Widerspruch zur Annahme $\Vert f\Vert_{0,2,\Omega}=1$.
 	Also folgt
 	\begin{align*}
-		\Vert f\Vert_{0,2,\Omega}\leq c\cdot\Vertiii{f}\qquad\forall f\in H^1(\Omega).
+		\norm{f}_{0,2,\Omega}\leq c\cdot\normiii{f}\qquad\forall f\in H^1(\Omega).
 	\end{align*}
 
-	\underline{Zeige $\|f\|_{1,2,\Omega}\leq c_1 \Vertiii{f}$}
+	\underline{Zeige $\abs{f}_{1,2,\Omega}\leq c_1 \normiii{f}$}
 
 	\begin{align*}
-		\Vert f\Vert_{1,2,\Omega}
+		\norm{f}_{1,2,\Omega}
 		&\leq
-		|f|_{1,2,\Omega}+\Vert f\Vert_{0,2,\Omega}\\
+		\abs{f}_{1,2,\Omega}+\norm{f}_{0,2,\Omega}\\
 		&\leq
-		\Vertiii{f}+c\cdot\Vertiii{f}\\
-		&=c_1\cdot\Vertiii{f}\qquad\forall f\in H^1(\Omega)
+		\normiii{f}+c\cdot\normiii{f}\\
+		&=c_1\cdot\normiii{f}\qquad\forall f\in H^1(\Omega)
 	\end{align*}
 \end{proof}
 

--- a/latex/commands.tex
+++ b/latex/commands.tex
@@ -78,6 +78,42 @@
 	\newcommand{\spann}{\Span}           % Span / Lineare Hülle
 \DeclareMathOperator{\supp}{supp}        % Träger
 \DeclareMathOperator{\tr}{tr}            % Spur
+
+% Normen, Betrag, Skalarprodukt
+% Quelle: https://tex.stackexchange.com/questions/94410/easily-change-behavior-of-declarepaireddelimiter
+% Beispiel: \set{...}; \set*{...}=\set[]{...}; \set[\big]{...}, \set[\Big]{...}, ...
+\NewDocumentCommand\xDeclarePairedDelimiter{mmm} % unär
+{
+	\NewDocumentCommand#1{som}{
+   		\IfNoValueTF{##2}
+	    {\IfBooleanTF{##1}{#2##3#3}{\mleft#2##3\mright#3}}
+    	{\mathopen{##2#2}##3\mathclose{##2#3}}
+	}
+}
+
+\NewDocumentCommand\xDeclarePairedDelimiterBin{mmm} % binär
+{
+	\NewDocumentCommand#1{somm}{
+   		\IfNoValueTF{##2}
+	    {\IfBooleanTF{##1}{#2##3,##4#3}{\mleft#2##3,##4\mright#3}}
+    	{\mathopen{##2#2}##3,##4\mathclose{##2#3}}
+	}
+}
+ 
+\xDeclarePairedDelimiter{\set}{\lbrace}{\rbrace}
+\xDeclarePairedDelimiter{\norm}{\Vert}{\Vert}
+\xDeclarePairedDelimiter{\abs}{\vert}{\vert}
+\xDeclarePairedDelimiterBin{\scaProd}{\langle}{\rangle}
+
+\NewDocumentCommand\normiii{som}{
+	\IfNoValueTF{#2} %falls optionales Argument leer (d.h. kein "\Big")
+	{\IfBooleanTF{#1}
+		{\vert\kern-0.25ex \vert\kern-0.25ex \vert #3 \vert\kern-0.25ex \vert\kern-0.25ex\vert} %normale Darstellung
+		{\mleft\vert\kern-0.25ex \mleft\vert\kern-0.25ex \mleft\vert #3 \mright\vert\kern-0.25ex \mright\vert\kern-0.25ex \mright\vert}
+	}
+    {\mathopen{#2\vert\kern-0.25ex #2\vert\kern-0.25ex #2\vert} #3 \mathclose{#2\vert\kern-0.25ex #2\vert\kern-0.25ex #2\vert}}
+}
+
 \newcommand{\Vertiii}[1]{
 	{\left\vert\kern-0.25ex\left\vert\kern-0.25ex\left\vert #1\right\vert\kern-0.25ex\right\vert\kern-0.25ex\right\vert}
 }                                        % dreifach gestrichene Norm
@@ -87,16 +123,14 @@
 \newcommand{\enter}{$ $\newline}         % Zeilenumbruch ohne Einschränkungen
 \newcommand\tab[1][1cm]{\hspace*{#1}}    % praktischer Tabulator
 
-% Folgende Commands sollten nicht mehr genutzt werden und sind nur noch zwecks "Abwärtskompatibilität" vorhanden
-\newcommand{\stackeq}[1]{\stackrel{#1}{=}}   
-
-% TEXT ÜBER UND UNTER ZEICHEN
+% overset und Co.
 \newcommand{\stackrelnew}[3]{\underset{#1}{\overset{#2}{#3}}}
+\newcommand{\stackeq}[1]{\overset{#1}{=}}  
 
 % Hervorhebungen
 \newcommand{\ul}[1]{\underline{#1}}    
 \newcommand{\define}[1]{\textbf{#1}}     % Definitionen sind standardmäßig fett
 \newcommand{\betone}[1]{\underline{#1}}  % Das zu Betonende ist standardmäßig unterstrichen
 
-% Warings and errors
+% Warnings and errors
 \newcommand{\throwWarning}[1]{\PackageWarning{42}{#1}} % Erzeugt LaTeX-Warnung mit Message = #1 

--- a/latex/commands.tex
+++ b/latex/commands.tex
@@ -114,10 +114,6 @@
     {\mathopen{#2\vert\kern-0.25ex #2\vert\kern-0.25ex #2\vert} #3 \mathclose{#2\vert\kern-0.25ex #2\vert\kern-0.25ex #2\vert}}
 }
 
-\newcommand{\Vertiii}[1]{
-	{\left\vert\kern-0.25ex\left\vert\kern-0.25ex\left\vert #1\right\vert\kern-0.25ex\right\vert\kern-0.25ex\right\vert}
-}                                        % dreifach gestrichene Norm
-
 % WHITESPACE COMMANDS
 \newcommand{\nl}{\\[\baselineskip]}      % Zeilenumbruch mit freier Zeile darunter OHNE underfull-hbox-warning
 \newcommand{\enter}{$ $\newline}         % Zeilenumbruch ohne Einschränkungen

--- a/latex/commands_Felix.tex
+++ b/latex/commands_Felix.tex
@@ -5,12 +5,10 @@
 
 % hier einige Befehle, die ich im Sinne der selbst-erklärheit der Codes sinnvoll finde:
 
-\newcommand{\abs}[1]{\left\lvert#1\right\rvert}     % absolute value
 \newcommand{\measure}[1]{\abs{#1}}    % measure (size) of a set
 \newcommand{\halfnorm}[1]{\left\lvert#1\right\rvert}     % Halbnorm
-\newcommand{\norm}[1]{\left\lVert#1\right\rVert}    % norm
 \newcommand{\rest}[2]{\left. #1 \right|_{#2}}  % restriction of function #1 to domain #2
-\newcommand{\scaProd}[2]{\left\langle#1, #2\right\rangle} % scalar product, could also use \rangle, \langle
+%\newcommand{\scaProd}[2]{\left\langle#1, #2\right\rangle} % scalar product, could also use \rangle, \langle
 \newcommand{\dualpair}[2]{\left\langle #1, #2 \right\rangle} % dual pairing, could also be #1 \left(#2\right)
 \newcommand{\Rand}[1]{\partial #1}  % Rand einer Menge. Wenn im Code \partial steht, verwirrt mich das, denn ich erwarte eine differenzierte Funktion 
 \newcommand{\setDef}[2]{\left\{#1 \,:\, #2\right\}}            % a typical set definition: #1 is the thing in the set #2 the condition on the variables {#1 : #2}

--- a/latex/demo_content.tex
+++ b/latex/demo_content.tex
@@ -11,7 +11,19 @@
 		\int\limits_\Omega\nabla u(x)\ds x&=12
 	\end{align*}
 	Hallo! \index{Hallo}
+	\begin{align*}
+		\set{f\in C(\R):\limn\int\limits_\R f(x)\ds x>42}\neq\set[\Big]{x\in\R:x+\underbrace{5+5}_{=10}\geq42}\\
+		\norm{a}=\norm{\sum\limits_{i=1}^n a_i}\qquad
+		\scaProd{a}{b}=\scaProd[\Big]{\int\limits_\Omega f\ds\mu(x)}{\int\limits_\Omega g\ds\mu(x)}\\
+		\scaProd{a}{b}=\scaProd*{a}{b}=\scaProd[\Big]{a}{b}
+	\end{align*}
 	\newpage
 	Hallo Welt! \index{Welt}
+	\begin{align*}
+		\normiii{a}
+		=\normiii{\sum\limits_i a_i}
+		=\normiii*{\sum\limits_i a_i}
+		=\normiii[\Big]{\sum\limits_i a_i}
+	\end{align*}
 	\newpage
 	Hi \index{hi! siehe auch {Hallo}} du!

--- a/latex/packages.tex
+++ b/latex/packages.tex
@@ -34,6 +34,7 @@
 \usepackage{lmodern}                     % provides a bigger set of font sizes
 \usepackage{makeidx}                     % erstellt Index / Stichwortverzeichnis
 \usepackage{mathrsfs}                    % für fancy \mathscr-Symbole
+\usepackage{mleftright}                  % für \DeclarePairedDelimiter
 \usepackage{pdflscape}                   % damit kann man einzelne Seiten ins Querformat drehen
 \usepackage{pgfplots}                    % damit kann man Funktionen plotten
 	\pgfplotsset{compat=newest}
@@ -52,6 +53,7 @@
 	\usetikzlibrary{shapes.geometric}
 \usepackage{xargs}                       % for multiple optional args in newcommand
 \usepackage{xfrac}
+\usepackage{xparse}                      % wichtig für \DeclarePairedDelimiter
 \usepackage{xr}                          % man Referenzen aus anderen teX-files importieren und darauf verlinken
 
 % Ich habe gelesen, dass man folgendes Package zuletzt einbinden soll:


### PR DESCRIPTION
Phillip hatte mir einen Tipp gegeben und ich habe mich mal schlau gemacht. Felix hatte mich sowie gebeten, commands wie \norm, \abs und \scaProd vorzudefinieren. Bisher hatte ich da immer keine gute Lösung gefunden, doch nun ist es soweit: Standardmäßig wird die Klammergröße mit \left \right angepasst, aber man kann per optionalem Argument nun auch manuelle Größen mitgeben, z.b: \big, \Big, ...
außerdem erreicht man die "Standardgröße" per Sternchen $\norm*{a}$. Schaut euch einfach die Beispiele an.

Der Code ist so Modular geschrieben, dass man jederzeit leicht eigene Befehle ergänzen kann.