### PR TITLE
typo fix Blatt_9_content.tex

### DIFF
--- a/nebenfaecher/FormaleSysteme/Blatt_9_content.tex
+++ b/nebenfaecher/FormaleSysteme/Blatt_9_content.tex
@@ -181,7 +181,7 @@ Umbenennung der Zustände des Quotientenautomaten:
 	\item $p_3:=\lbrace q_0,q_2\rbrace$
 	\item $p_4:=\lbrace q_0,q_1,q_2,q_3\rbrace$
 	\item $p_5:=\lbrace q_0,q_2,q_3\rbrace$
-	\item $p_6:=\lbrace q_0,q_1,2_3\rbrace$
+	\item $p_6:=\lbrace q_0,q_1,q_3\rbrace$
 	\item $p_7:=\lbrace q_0,q_3\rbrace$
 \end{itemize}
 


### PR DESCRIPTION
should be {q0, q1, q3} insted of ..2_3}